### PR TITLE
Add `developerMode` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See the [O-FISH installation guide](https://wildaid.github.io/), which includes 
 Before activating sync, you can add extra security by adding this extra rule to the read and write permissions: `{ "%%user.custom_data.agency.name": "%%partition" }`.
 1. Enable Users/Custom Data (ensure that cluster name = `RealmSync`, database = `wildaid`, collection = `User` and user ID field = `realmUserId`)
 1. Optionally enable additional Triggers through the Realm UI (if you've set up your AWS credentials)
-1. If you want to allow anonymous users to create a new account and agency (only intended for shared development environments/sandboxes), then enable Anonymous Authentication so that the `regNewAgency` function can be called from the web app.
+1. If you want to allow anonymous users to create a new account and agency (only intended for shared development environments/sandboxes), then enable Anonymous Authentication and set the `developerMode` Realm value to `ture` so that the `regNewAgency` function can be called from the web app.
 
 
 ## O-FISH <A NAME="components">Components</A>

--- a/WildAidDemo/functions/regNewAgency/source.js
+++ b/WildAidDemo/functions/regNewAgency/source.js
@@ -12,6 +12,14 @@
 */
 exports = function(firstName, lastName, email, agencyName, agencyURL) {
   console.log(`Attempting to create Agency & User documents for user ${email} and agency ${agencyName}`);
+  
+  const developerMode = context.values.get("developerMode");
+  if (!developerMode) {
+    const errorText = `developerMode not enabled in backend Realm app`;
+      console.log(errorText);
+      return {result: "error", reason: errorText};
+  }
+  
   var database = context.services.get("mongodb-atlas").db("wildaid");
   var userCollection = database.collection("User");
   var agencyCollection = database.collection("Agency");
@@ -39,7 +47,7 @@ exports = function(firstName, lastName, email, agencyName, agencyURL) {
           })
           .then ( _ => {
             return userCollection.insertOne({
-              agency: {name: agencyName, admin: false},
+              agency: {name: agencyName, admin: true},
               createdOn: new Date(),
               email: email,
               global: {admin: false},

--- a/WildAidDemo/values/developerMode.json
+++ b/WildAidDemo/values/developerMode.json
@@ -1,0 +1,5 @@
+{
+    "name": "developerMode",
+    "value": false,
+    "from_secret": false
+}


### PR DESCRIPTION
[-] Add `developerMode` value and default it to `false`
[-] Have `regNewAgency` check that `developerMode` is set to `true` before adding the agency and user
[-] `regNewAgency` creates the user as an agency-admin
fixes #146 