### PR TITLE
check agency name against agency.name, not agency

### DIFF
--- a/WildAidDemo/functions/isAgencyAdmin/source.js
+++ b/WildAidDemo/functions/isAgencyAdmin/source.js
@@ -1,9 +1,9 @@
 exports = function(agency, emailAddress){
-  console.log(`Checking email address: ${emailAddress} for agency: ${agency}`);
+  console.log(`Checking email address: ${emailAddress} for agency: ${agency.name}`);
   var userCollection = context.services.get("mongodb-atlas")
     .db("wildaid").collection("User");
   
-  return userCollection.findOne({email: emailAddress, agency: {name: agency, admin: true}})
+  return userCollection.findOne({email: emailAddress, agency: {name: agency.name, admin: true}})
   .then ( userDoc => { 
     if (userDoc) {
       console.log('Matches Agency Admin rule');


### PR DESCRIPTION
Found this bug while investigating why agency admins could not create users, but global admins could.
fixes #173 

- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).
