### PR TITLE
Cope with `outBoundPartnerAgencies` not being set

### DIFF
--- a/WildAidDemo/functions/updateInboundPartners/source.js
+++ b/WildAidDemo/functions/updateInboundPartners/source.js
@@ -1,4 +1,5 @@
 exports = function(changeEvent) {
+  if (!changeEvent.fullDocument.outBoundPartnerAgencies) { return }
   const agencyCollection = context.services.get("mongodb-atlas").db("wildaid").collection("Agency");
   const agency = changeEvent.fullDocument.name
 


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes #

## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [ ] I linked an issue in the previous section
- [ ] I have commented on the linked issue
- [ ] I was assigned the linked issue (not required)
- [ ] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 



* **Optional: Add any relevant screenshots here** 



