### PR TITLE
an Agency's users should be gotten from the User collection

### DIFF
--- a/WildAidDemo/functions/searchFacetByAgency/source.js
+++ b/WildAidDemo/functions/searchFacetByAgency/source.js
@@ -2,8 +2,8 @@ exports = function(limit, offset, query, filter){
 var agencyCollection = context.services.get("mongodb-atlas")
   .db("wildaid").collection("Agency");
 
-var boardingsCollection = context.services.get("mongodb-atlas")
-    .db("wildaid").collection("BoardingReports");
+var userCollection = context.services.get("mongodb-atlas")
+    .db("wildaid").collection("User");
 
 if (!query){
   var amount = 0;
@@ -50,11 +50,12 @@ if (!query){
         }
       ]).toArray();
   }
-  var officers = boardingsCollection.aggregate([
+
+  var officers = userCollection.aggregate([
   {
     $project: {
-      'agency': '$agency',
-      'officer': {$concat: ['$reportingOfficer.name.first', ' ', '$reportingOfficer.name.last']}
+      'agency': '$agency.name',
+      'officer': {$concat: ['$name.first', ' ', '$name.last']}
     }
   },
   {


### PR DESCRIPTION
previously it was getting from the Boarding Reports collection.

## Related Issue
This made the agencies page have the incorrect number of users, because users who didn't submit any boarding records weren't counted. I noticed this after merging https://github.com/WildAid/o-fish-realm/issues/189

I tested this in the sandbox server. The function is only ever used in the searchAgencies service, which is used on this page and on components/partials/user-editor/user-editor.component.js - and that page only uses the agency name, not any of the officers in the agency.
