### PR TITLE
add mising attributes for return vessels and crews in 'search' function

### DIFF
--- a/WildAidDemo/functions/search/source.js
+++ b/WildAidDemo/functions/search/source.js
@@ -18,6 +18,7 @@ exports = function(query){
   }, {
    '$group' : {
      _id : '$vessel.name',
+     permitNumber: { $first: '$vessel.permitNumber' },
      catches: { $push: "$inspection.actualCatch.fish" }
     }
   },{
@@ -64,7 +65,9 @@ exports = function(query){
   }, {
     '$project': {
       'captain.name': 1, 
+      'captain.license': 1,
       'crew.name': 1, 
+      'crew.license': 1,
       'vessel.name': 1,
       'highlights': {
         '$meta': 'searchHighlights'


### PR DESCRIPTION
## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- Please link to the issue by adding the issue number after the #: -->

Fixes the data side of o-fish-web issue 63
https://github.com/WildAid/o-fish-web/issues/63


## Checklist:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [x] I have read the [contributor's guide](https://wildaid.github.io/contribute/index.html).
- [x] I linked an issue in the previous section
- [x] I have commented on the linked issue
- [x] I was assigned the linked issue (not required)
- [x] I have tested the change to the best of my ability against the [sandbox](https://wildaid.github.io/contribute/sandbox.html) or a [local build](https://wildaid.github.io/build).

Optional items:
<!--- Please check off any appropriate boxes by replacing the whitespace with an `x` in the box -->
- [ ] My change adds new text and requires a change to translations.
- [ ] My change requires a change to the documentation.
- [ ] I have submitted a PR to the [documentation repo](https://github.com/WildAid/wildaid.github.io).
- [ ] I was not able to test... (explain below, e.g. you did not have permissions to test a specific feature)
- [ ] This change depends O-FISH Web repository changes (explain below)

* **Optional: Add any explanations here** 

This is the necessary change to the Realm "search" function so that the UI can get these attributes 
and pass them to the component that generates the `<Link>` so that the proper filter can be included in the path

see UI ticket for details:
https://github.com/WildAid/o-fish-web/pull/352

* **Optional: Add any relevant screenshots here** 




